### PR TITLE
401 filter inverts

### DIFF
--- a/R/diag_cohortBiomass.r
+++ b/R/diag_cohortBiomass.r
@@ -50,8 +50,7 @@ diag_cohortBiomass <- function(fgs,
   mort <- utils::read.csv(mortality,sep = " ", stringsAsFactors=FALSE, header=TRUE)
   mort <- dplyr::select(mort,dplyr::contains(".F"))
   mort_l20 <- dplyr::slice(mort,-c(1:34,55))
-  meanMort <- dplyr::summarize_all(mort_l20,mean)
-
+  meanMort <- colMeans(mort_l20) %>% t() %>% as.data.frame()
 
   neusPriority <- utils::read.csv(neusPriority,sep=",",stringsAsFactors=FALSE,header=TRUE) %>%
     dplyr::rename(priority = .data$priority.overall) %>%

--- a/R/diag_cohortBiomass.r
+++ b/R/diag_cohortBiomass.r
@@ -40,6 +40,8 @@ diag_cohortBiomass <- function(fgs,
     speciesCodes <- allCodes
   }
 
+  #pull all species with >= 2 groups that are FISH
+  ageCodes <- atlantistools::get_age_acronyms(fgs)
 
   cohortBiom <- utils::read.csv(agebiomind,sep = " ", stringsAsFactors=FALSE, header=TRUE)
   mort <- utils::read.csv(mortality,sep = " ", stringsAsFactors=FALSE, header=TRUE)
@@ -110,6 +112,7 @@ diag_cohortBiomass <- function(fgs,
 
   diagnostics <- diagnostics %>%
     dplyr::arrange(.data$priority,.data$pass,.data$maxCohort,.data$stability,.data$fishing,.data$code) %>%
+    dplyr::filter(.data$code %in% ageCodes) %>%
     tibble::as_tibble()
 
   return(diagnostics)

--- a/man/diag_cohortBiomass.Rd
+++ b/man/diag_cohortBiomass.Rd
@@ -9,7 +9,8 @@ diag_cohortBiomass(
   mortality,
   agebiomind,
   speciesCodes = NULL,
-  neusPriority
+  neusPriority,
+  fishedSpecies = 2
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ diag_cohortBiomass(
 (Default = NULL, uses all species with \code{IsTurnedOn=1} in \code{fgs} file)}
 
 \item{neusPriority}{A character string. Path to location of Species Priorities file.}
+
+\item{fishedSpecies}{Numeric scalar. Filter by how much species are fished. Values = 1 (most), 2, 3, 4 (least)
+(Default = 2. Only species fished at level <= 2 will be returned)}
 }
 \value{
 \item{code}{Atlantis species code}


### PR DESCRIPTION
## diag_cohortsBiomass.r

* Filters out inverts. Only displays FISH (as designated in `functionalGroups.csv`) with 2 or more cohorts
* Added `fishedSpecies` argument allowing user to filter results based on how hard a species is fished (1:4)
* Replaced depreciated functions `summarise_each` and `summarise_all` to avoid warnings